### PR TITLE
Added external jquery link to karma.conf.js, refactored geolocation_spec...

### DIFF
--- a/school-finder-frontend/karma.conf.js
+++ b/school-finder-frontend/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function(config) {
     files: [
       'node_modules/angular/angular.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js',
       'node_modules/angular-ui-router/release/angular-ui-router.js',
       'node_modules/leaflet/dist/leaflet.js',
       'node_modules/angular-leaflet-directive/dist/angular-leaflet-directive.js',

--- a/school-finder-frontend/tests/geolocation/geolocation_spec.js
+++ b/school-finder-frontend/tests/geolocation/geolocation_spec.js
@@ -1,8 +1,7 @@
-// mocha, chai, chai-as-promised, Angular mocks
-
 // npm install
 // cd to shool-finder-frontend
 // npm test
+//  * If you're on Windows: install karma-cli globally and run: karma start
 
 // mocha timeout and slow variables are set fairly high in karma.conf.js... I have a slow ass Windows box :(
 describe('School Finder: geolocationFactory', function () {
@@ -43,9 +42,12 @@ describe('School Finder: geolocationFactory', function () {
     $rootScope = _$rootScope_;
   }));
 
+  // each assertion is wrapped in a $rootScope.$apply in order to force Angular to digest our mocked getCurrentPosition since it's using the native setTimeout to emulate a promise
   describe('Call to geolcoationFactory.getCurrentPosition()', function () {
     it('should resolve to a fullfilled promise that eventually resolves to a position object that has the coords property', function () {
-      return expect(geo.getCurrentPosition()).to.eventually.have.property("position").that.has.property('coords');
+      $rootScope.$apply(function () {
+        return expect(geo.getCurrentPosition()).to.eventually.have.property("position").that.has.property('coords');
+      });
     });
   });
 
@@ -55,8 +57,6 @@ describe('School Finder: geolocationFactory', function () {
     });
 
     it('it should return a rejected promise that eventually returns error.code = 2 - POSITION_UNAVAILABLE (not available on the browser)', function () {
-      // Manually forcing Angular to run a digest cycle because the factory returns a deferred.promise with a a rejected state when geolocation is not supported.
-      // As opposed to the factory returns a deferred.promise with a a pending state when geolocation is supported.
       $rootScope.$apply(function () {
         return geo.getCurrentPosition().should.eventually.be.rejected
           .and.eventually.have.property("error")
@@ -73,10 +73,12 @@ describe('School Finder: geolocationFactory', function () {
     });
 
     it('it should return a rejected promise that eventually returns error.code = 1 - PERMISSION_DENIED (user denied access)', function () {
-      return geo.getCurrentPosition().should.eventually.be.rejected
-        .and.eventually.have.property("error")
-        .that.has.property('code')
-        .that.equals(1);
+      $rootScope.$apply(function () {
+        return geo.getCurrentPosition().should.eventually.be.rejected
+          .and.eventually.have.property("error")
+          .that.has.property('code')
+          .that.equals(1);
+      });
     });
   });
 
@@ -87,10 +89,12 @@ describe('School Finder: geolocationFactory', function () {
     });
 
     it('it should return a rejected promise that eventually returns error.code = 2 - POSITION_UNAVAILABLE (user denied access)', function () {
-      return geo.getCurrentPosition().should.eventually.be.rejected
-        .and.eventually.have.property("error")
-        .that.has.property('code')
-        .that.equals(2);
+      $rootScope.$apply(function () {
+        return geo.getCurrentPosition().should.eventually.be.rejected
+          .and.eventually.have.property("error")
+          .that.has.property('code')
+          .that.equals(2);
+      });
     });
   });
 
@@ -101,10 +105,12 @@ describe('School Finder: geolocationFactory', function () {
     });
 
     it('it should return a rejected promise that eventually returns error.code = 3 - TIMEOUT (the option.timeout was set and eclipsed)', function () {
-      return geo.getCurrentPosition().should.eventually.be.rejected
-        .and.eventually.have.property("error")
-        .that.has.property('code')
-        .that.equals(3);
+      $rootScope.$apply(function () {
+        return geo.getCurrentPosition().should.eventually.be.rejected
+          .and.eventually.have.property("error")
+          .that.has.property('code')
+          .that.equals(3);
+      });
     });
   });
 


### PR DESCRIPTION
[#48] is closed... But, Karma was still complaining:
>Error: Bootstrap's JavaScript requires jQuery
>at http://localhost:9876/base/app/scripts/bootstrap.min.js?313da686ebbe387064f2d1899c64ea562b81eb40:6

- Added a https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js file reference into karma.conf.js

[Pull Request #51] [Removed the $rootScope.$apply methods](https://github.com/codeforokc/school-finder/blob/master/school-finder-frontend/app/geolocationFactory.js#L15-20). But, this caused the geolocation unit tests to fail.

- Wrapped each assertion in a $rootScope.$apply in order to force Angular to digest the mocked getCurrentPosition since it's using the native setTimeout to emulate a promise
